### PR TITLE
fix: 修复 CI 下 pnpm install 失败，并补充 Teek 主题配置说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ const sidebars: DefaultTheme.SidebarItem[] = [
 > 
 > pnpm install
 > 
-> npm run docs:dev
+> pnpm run docs:dev
 > 
 > 然后在浏览器输入所给出的地址
+
+## 主题配置
+
+站点使用了 **vitepress-theme-teek** 主题，主题相关配置（博主、页脚、社交、主题色、首页/文章页样式等）统一放在 **`.vitepress/teek-config.ts`**（`.vitepress/config.mts` 里 `extends: teekConfig` 引入）。想改主题外观、色板、文章页样式等，改这个文件即可；导航与侧边栏仍按上面的方式在 `config.mts` / `.vitepress/sidebars` 里配置。

--- a/package.json
+++ b/package.json
@@ -16,10 +16,5 @@
     "sass": "^1.103.1",
     "vitepress": "1.6.4",
     "vitepress-theme-teek": "1.6.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "vitepress": "1.6.4"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
-  '@parcel/watcher': set this to true or false
+  '@parcel/watcher': true
   esbuild: true


### PR DESCRIPTION
- pnpm-workspace.yaml: 放行 @parcel/watcher 构建脚本（原为占位字符串， 导致 ERR_PNPM_IGNORED_BUILDS、CI 退出码 1）
- package.json: 移除 pnpm v11 已忽略的 pnpm.overrides 字段
- README.md: 统一为 pnpm run docs:dev，并新增「主题配置」说明 （主题外观/色板等改 .vitepress/teek-config.ts）